### PR TITLE
Update module to support 'opts.warnings'.

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,9 @@ module.exports = function (input_obj, opts) {
 
   for (index in barWidths) {
     if (barWidths[index] === 0) {
-      console.log("This terminal's width is too less!" + (labelsTrue ? ' You can remove labels, and try again!' : ''))
+      if (opts.warnings) {
+        console.log("This terminal's width is too less!" + (labelsTrue ? ' You can remove labels, and try again!' : ''))
+      }
       break
     }
   }

--- a/readme.md
+++ b/readme.md
@@ -79,6 +79,13 @@ Type: `Boolean`
 Default: `false`  
 Labels to be shown or not
 
+##### warnings
+
+*Optional*
+Type: `Boolean`
+Default: `false`
+Whether or not to show warnings (eg. 'missing/invalid input')
+
 ## License
 
 MIT © [Siddharth Kannan](http://icyflame.github.io)


### PR DESCRIPTION
PR allows for warnings (such as: "This terminal's window is too less...") to be enabled/disabled by providing a 'warnings' key on the `opts` object.

If the 'warnings' key *does not* contain a truthy value at invocation time, then the warning messages will be suppressed.

P.S. This update is useful for my [goalist](https://github.com/jrmykolyn/goalist) package, and I thought you might want to make it available to anyone else that's using `barHorizontal`.