### PR TITLE
Add ascii support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 'use strict'
 module.exports = function (input_obj, opts) {
-  var barChar = require('figures').square
+  // Ensure that `opts` is always an object.
+  opts = (opts && typeof opts === 'object') ? opts : {}
+
+  var barChar = (opts.ascii === true || opts.ascii === 'true') ? '=' : require('figures').square
   var Stats = require('fast-stats').Stats
   var width = require('window-size').width
   var ObjectValues = require('object.values')
@@ -11,14 +14,7 @@ module.exports = function (input_obj, opts) {
   var barWidths = []
   var index
   var values = ObjectValues(input_obj)
-
-  var printValues = false;
-
-  if (opts !== undefined) {
-	  if (opts.values === 'true' || opts.values === true) {
-		  printValues = true;
-	  }
-  }
+  var printValues = (opts.values === 'true' || opts.values === true);
 
   // TODO: Oneliner
   for (index in input_obj) {

--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,13 @@ Type: `Boolean`
 Default: `false`
 Whether or not to show warnings (eg. 'missing/invalid input')
 
+##### ascii
+
+*Optional*
+Type: `Boolean`
+Default: `false`
+Whether or not to use the `=` when printing the bar graph(s) to stdout. If this argument is missing/falsy, the `|` character will be used instead.
+
 ## License
 
 MIT © [Siddharth Kannan](http://icyflame.github.io)


### PR DESCRIPTION
Updated module to support the `ascii` key on the `opts` object. Fixes #5.

If `barHorizontal` is invoked with this option (value must be either `true` or `'true'`), then the `=` character will be used when printing the bar charts to stdout. If this option is omitted (or if an invalid value is provided), then the `|` char will be used.

Please note:
- This PR also contains minor updates to how the `opts` and `printValues` variables are assigned.
